### PR TITLE
Fixing accidental open when in a scroll view

### DIFF
--- a/library/src/main/java/com/daimajia/swipe/SwipeAdapter.java
+++ b/library/src/main/java/com/daimajia/swipe/SwipeAdapter.java
@@ -78,11 +78,9 @@ public abstract class SwipeAdapter extends BaseAdapter {
      * @param mode
      */
     public void setMode(Mode mode){
-        if(mode == Mode.Multiple){
-            mOpenPositions.clear();
-        }else{
-            mOpenPosition = INVALID_POSITION;
-        }
+        // Clear currently set values
+        mOpenPositions.clear();
+        mOpenPosition = INVALID_POSITION;
         this.mode = mode;
         notifyDataSetChanged();
     }

--- a/library/src/main/java/com/daimajia/swipe/SwipeLayout.java
+++ b/library/src/main/java/com/daimajia/swipe/SwipeLayout.java
@@ -930,7 +930,7 @@ public class SwipeLayout extends FrameLayout {
      */
     private void processSurfaceRelease(float xvel, float yvel){
         if(xvel == 0 && getOpenStatus() == Status.Middle)
-            open();
+            close();
 
         if(mDragEdge == DragEdge.Left || mDragEdge == DragEdge.Right){
             if(xvel > 0){


### PR DESCRIPTION
When at the top of a listview or other scroll view, trying to scroll further up causes an accidental open of the swipe layout. This has been fixed.

Also when setting the mode of the adaptor, the selected position needs to be cleared for all cases.
