### PR TITLE
Update version number for Gradle and Maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ When I start to make this library, I set some goals:
 dependencies {
     compile 'com.android.support:recyclerview-v7:21.0.0'
     compile 'com.android.support:support-v4:20.+'
-    compile "com.daimajia.swipelayout:library:1.1.8@aar"
+    compile "com.daimajia.swipelayout:library:1.1.9@aar"
 }
 ```
 
@@ -60,7 +60,7 @@ dependencies {
 <dependency>
     <groupId>com.daimajia.swipelayout</groupId>
     <artifactId>library</artifactId>
-    <version>1.1.8</version>
+    <version>1.1.9</version>
     <type>apklib</type>
 </dependency>
 ```


### PR DESCRIPTION
Eclipse and Demo version numbers can't be increased because the jar and apk haven't been added to releases.