### PR TITLE
i find a bug when Mode.Single

### DIFF
--- a/library/src/main/java/com/daimajia/swipe/implments/SwipeItemMangerImpl.java
+++ b/library/src/main/java/com/daimajia/swipe/implments/SwipeItemMangerImpl.java
@@ -193,6 +193,7 @@ public class SwipeItemMangerImpl implements SwipeItemMangerInterface {
             if(mode == Mode.Multiple){
                 mOpenPositions.remove(position);
             }else{
+                if(position == mOpenPosition)
                 mOpenPosition = INVALID_POSITION;
             }
         }


### PR DESCRIPTION
when i open the second item, i find the first call thread is onOpen(SwipeLayout layout) at the second item  position,  then call the onClose(SwipeLayout layout) at first item position, 

So, Even if i have one item is opened,  but  mOpenPosition = INVALID_POSITION;