### PR TITLE
gradle: add jitpack.io support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,13 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url "https://jitpack.io"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.github.dcendents:android-maven-plugin:1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -15,5 +19,8 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url "https://jitpack.io"
+        }
     }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -15,3 +15,13 @@ dependencies {
     compile 'com.android.support:support-v4:22.1.1'
 }
 apply from: './gradle-mvn-push.gradle'
+
+apply plugin: 'android-maven'
+// build a jar with source files
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+artifacts {
+    archives sourcesJar
+}


### PR DESCRIPTION
allows to easily include new versions via gradle.

for example
https://jitpack.io/#Evisceration/AndroidSwipeLayout/0734b92f88

you can grab the library's state from any commit if you supply the short hash of the commit or also check out tags and releases you push.

makes it way easier for you, as you do not need to push to maven manually :)