### PR TITLE
Added function to manually reset offsets of bottomview 

### DIFF
--- a/library/src/main/java/com/daimajia/swipe/SwipeLayout.java
+++ b/library/src/main/java/com/daimajia/swipe/SwipeLayout.java
@@ -58,6 +58,7 @@ public class SwipeLayout extends FrameLayout {
     private boolean mSwipeEnabled = true;
     private boolean[] mSwipesEnabled = new boolean[]{true, true, true, true};
     private boolean mClickToClose = false;
+    private AttributeSet attrs;
 
     public enum DragEdge {
         Left,
@@ -81,15 +82,14 @@ public class SwipeLayout extends FrameLayout {
 
     public SwipeLayout(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
+        this.attrs = attrs;
         mDragHelper = ViewDragHelper.create(this, mDragHelperCallback);
         mTouchSlop = ViewConfiguration.get(context).getScaledTouchSlop();
 
         TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.SwipeLayout);
+        resetOffsets();
         int dragEdgeChoices = a.getInt(R.styleable.SwipeLayout_drag_edge, DRAG_RIGHT);
-        mEdgeSwipesOffset[DragEdge.Left.ordinal()] = a.getDimension(R.styleable.SwipeLayout_leftEdgeSwipeOffset, 0);
-        mEdgeSwipesOffset[DragEdge.Right.ordinal()] = a.getDimension(R.styleable.SwipeLayout_rightEdgeSwipeOffset, 0);
-        mEdgeSwipesOffset[DragEdge.Top.ordinal()] = a.getDimension(R.styleable.SwipeLayout_topEdgeSwipeOffset, 0);
-        mEdgeSwipesOffset[DragEdge.Bottom.ordinal()] = a.getDimension(R.styleable.SwipeLayout_bottomEdgeSwipeOffset, 0);
+
         setClickToClose(a.getBoolean(R.styleable.SwipeLayout_clickToClose, mClickToClose));
 
         if ((dragEdgeChoices & DRAG_LEFT) == DRAG_LEFT) {
@@ -108,6 +108,21 @@ public class SwipeLayout extends FrameLayout {
         mShowMode = ShowMode.values()[ordinal];
         a.recycle();
 
+    }
+
+    /**
+     * Reset offsets of BottomView to prevent it scrolling across the screen when
+     * Certain versions of the close method are manually used.
+     * close(true, true) at the least.
+     */
+    public void resetOffsets() {
+        TypedArray a = getContext() .obtainStyledAttributes(attrs, R.styleable.SwipeLayout);
+
+        mEdgeSwipesOffset[DragEdge.Left.ordinal()] = a.getDimension(R.styleable.SwipeLayout_leftEdgeSwipeOffset, 0);
+        mEdgeSwipesOffset[DragEdge.Right.ordinal()] = a.getDimension(R.styleable.SwipeLayout_rightEdgeSwipeOffset, 0);
+        mEdgeSwipesOffset[DragEdge.Top.ordinal()] = a.getDimension(R.styleable.SwipeLayout_topEdgeSwipeOffset, 0);
+        mEdgeSwipesOffset[DragEdge.Bottom.ordinal()] = a.getDimension(R.styleable.SwipeLayout_bottomEdgeSwipeOffset, 0);
+        a.recycle();
     }
 
     public interface SwipeListener {


### PR DESCRIPTION
Using 
```java 
swipeLayout.close(true, true); 
``` 
doesn't appear to guarantee this. I suspect the library assumes the user is manually closing the task and doesn't upset the offset in all or some cases. Adding manual resetting of offset allowed the use of Google Inbox like swipe-to-delete functionality:

Example listener with the new function:
```java
  swipeLayout.addSwipeListener(new SwipeLayout.SwipeListener() {


            public void onStartOpen(SwipeLayout swipeLayout) {

            }

            @Override
            public void onOpen(SwipeLayout swipeLayout) {

            }

            @Override
            public void onStartClose(SwipeLayout swipeLayout) {

            }

            @Override
            public void onClose(SwipeLayout swipeLayout) {

            }

            @Override
            public void onUpdate(SwipeLayout swipeLayout, int i, int i2) {

            }

            @Override
            public void onHandRelease(SwipeLayout swipeLayout, float xvel, float yvel) {

                //If item is fully open commence delete action.
                if (swipeLayout.getOpenStatus().equals(SwipeLayout.Status.Open)) {
                    Toast.makeText(context, "Item deleted", Toast.LENGTH_SHORT).show();
                   //Action to remove item here.
                }
                //If it is half open then close item, we don't want to delete unless the user
                //scrolls all the way.
                else if (swipeLayout.getOpenStatus().equals(SwipeLayout.Status.Middle)){
                    swipeLayout.close(true, true);
                    //Use resetOffsets to prevent bug
                    // where bottomView scrolls across the item
                    // more and more
                    // on each half-open-release event
                    swipeLayout.resetOffsets();

                }
            }
        });
```

Of course if you have any idea how to duplicate this functionality without exposing the extra function then go for it or I can do it with guidance/time. I would have attempted this but I think it would have risked bugging out the "smooth" close function parameter .