### PR TITLE
Update ArraySwipeAdapter.java

### DIFF
--- a/library/src/main/java/com/daimajia/swipe/adapters/ArraySwipeAdapter.java
+++ b/library/src/main/java/com/daimajia/swipe/adapters/ArraySwipeAdapter.java
@@ -13,7 +13,7 @@ import com.daimajia.swipe.util.Attributes;
 
 import java.util.List;
 
-public abstract class ArraySwipeAdapter<T> extends ArrayAdapter implements SwipeItemMangerInterface, SwipeAdapterInterface {
+public abstract class ArraySwipeAdapter<T> extends ArrayAdapter<T> implements SwipeItemMangerInterface, SwipeAdapterInterface {
 
     private SwipeItemMangerImpl mItemManger = new SwipeItemMangerImpl(this);
     {}


### PR DESCRIPTION
Add generic type to extends ArrayAdapter.
Example:
public static class MyAdapter extend ArraySwipeAdapter<String>{
...
}
private MyAdapter adapter = new MyAdapter(...);
...
old version:
String str = (String)adapter.getItem(0);
New version:
String str = adapter.getItem(0);