### PR TITLE
#289 fix bug - long press doesn't trigger onClick event

### DIFF
--- a/library/src/main/java/com/daimajia/swipe/SwipeLayout.java
+++ b/library/src/main/java/com/daimajia/swipe/SwipeLayout.java
@@ -1147,8 +1147,7 @@ public class SwipeLayout extends FrameLayout {
                 setOnLongClickListener(new OnLongClickListener() {
                     @Override
                     public boolean onLongClick(View v) {
-                        performAdapterViewItemLongClick();
-                        return true;
+                        return performAdapterViewItemLongClick();
                     }
                 });
             }


### PR DESCRIPTION
this commit is modified from 84001f5 (release v1.2.0 on Apr 20, 2015)
and it works fine with ripple effect.