### PR TITLE
Add hasSwipeListeners method to SwipeLayout

### DIFF
--- a/library/src/main/java/com/daimajia/swipe/SwipeLayout.java
+++ b/library/src/main/java/com/daimajia/swipe/SwipeLayout.java
@@ -127,6 +127,10 @@ public class SwipeLayout extends FrameLayout {
         void onHandRelease(SwipeLayout layout, float xvel, float yvel);
     }
 
+    public boolean hasSwipeListeners(){
+        return mSwipeListeners.isEmpty();
+    }
+
     public void addSwipeListener(SwipeListener l) {
         mSwipeListeners.add(l);
     }


### PR DESCRIPTION
Helps to avoid adding multiple listeners when the view is recycled, causing multiple calls on onOpen() for each position