### PR TITLE
Set mOpenPosition to INVALID_POSITION only if the one opened

### DIFF
--- a/library/src/main/java/com/daimajia/swipe/implments/SwipeItemMangerImpl.java
+++ b/library/src/main/java/com/daimajia/swipe/implments/SwipeItemMangerImpl.java
@@ -185,7 +185,7 @@ public class SwipeItemMangerImpl implements SwipeItemMangerInterface {
         public void onClose(SwipeLayout layout) {
             if (mode == Attributes.Mode.Multiple) {
                 mOpenPositions.remove(position);
-            } else {
+            } else if (mOpenPosition == position) {
                 mOpenPosition = INVALID_POSITION;
             }
         }


### PR DESCRIPTION
Without this fix when you swipe a view then swipe another and refresh the adapter, the second will automatically be closed